### PR TITLE
Fix end of unexpected json input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,40 @@
+# Windows Container Networking CNI
+[![Go Report Card](https://goreportcard.com/badge/github.com/Microsoft/windows-container-networking)]
+(https://goreportcard.com/report/github.com/Microsoft/windows-container-networking)
 
-# Contributing
+## Overview
+This repo contains plugins meant for testing/development of latest windows features. Their primary use case right now is with a CRI and containerd
+
+## CNI Plugins Available
+* `sdnoverlay`
+* `nat`
+* `sdnbridge`
+
+## Releases
+Currently you must build the binaries yourself (see below)
+
+* ToDo: Automated Release
+
+## Build
+These plugins are made for windows and need to be compiled for windows
+
+If you have make installed on your system:
+
+`make all` \ `make <plugin>`
+
+Else:
+
+`GOOS=windows GOARCH=amd64 go build -v -o out/<plugin>.exe plugins/<plugin>/*.go` 
+
+## Testing
+There is a test suite that should be run (`make test`) before any changes. Opening a PR should trigger a Jenkins run that will run all the tests. If you wish to run them locally, you'll need a nanoserver image pulled from docker. 
+
+Currently there are two groups of end-to-end tests shared by all the plugins
+
+* Properties Verification - tests an add command and verifies that the resulting state is as expected. I.e. we attach an endpoint that endpoint has policy x,y,z etc. 
+* Connectivity Testing -  creates a container and makes a CNI call for it and verifies that the container has connectivity for pod-to-pod, host-to-pod, pod-to-host, and pod-to-internet
+
+## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
@@ -9,6 +44,5 @@ When you submit a pull request, a CLA-bot will automatically determine whether y
 a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
 provided by the bot. You will only need to do this once across all repos using our CLA.
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+## Code of Conduct
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/network/policy.go
+++ b/network/policy.go
@@ -5,7 +5,7 @@ package network
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"github.com/Microsoft/hcsshim/hcn"
 	"strings"
 )
@@ -24,7 +24,7 @@ type Policy struct {
 }
 
 // GetPortMappingPolicy creates an HCN PortMappingPolicy and stores it in CNI Policy.
-func GetPortMappingPolicy(externalPort int, internalPort int, protocol string) Policy {
+func GetPortMappingPolicy(externalPort int, internalPort int, protocol string) (Policy, error) {
 	var protocolInt uint32
 	switch strings.ToLower(protocol) {
 	case "tcp":
@@ -43,7 +43,7 @@ func GetPortMappingPolicy(externalPort int, internalPort int, protocol string) P
 		protocolInt = 2
 		break
 	default:
-		panic(fmt.Errorf("invalid protocol supplied to port mapping policy"))
+		return Policy{}, errors.New("invalid protocol supplied to port mapping policy")
 	}
 
 	portMappingPolicy := hcn.PortMappingPolicySetting{
@@ -61,5 +61,5 @@ func GetPortMappingPolicy(externalPort int, internalPort int, protocol string) P
 	return Policy{
 		Type: EndpointPolicy,
 		Data: rawData,
-	}
+	}, nil
 }

--- a/plugins/nat/nat_windows_test.go
+++ b/plugins/nat/nat_windows_test.go
@@ -3,7 +3,6 @@ package main_test
 import (
 	"github.com/Microsoft/windows-container-networking/test/utilities"
 	"github.com/Microsoft/hcsshim/hcn"
-	"github.com/Microsoft/windows-container-networking/test/container"
 	"testing"
 )
 

--- a/plugins/nat/nat_windows_test.go
+++ b/plugins/nat/nat_windows_test.go
@@ -14,7 +14,6 @@ func CreateNatTestNetwork() *hcn.HostComputeNetwork {
 
 
 func TestNatCmdAdd(t *testing.T) {
-	t.Skip("Nat test is disabled for now.")
 	testNetwork := CreateNatTestNetwork()
 	pt := util.MakeTestStruct(t, testNetwork, "nat", false, false,"")
 	pt.RunBasicConnectivityTest(t, 2)

--- a/plugins/sdnoverlay/sdnoverlay_windows_test.go
+++ b/plugins/sdnoverlay/sdnoverlay_windows_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"github.com/Microsoft/hcsshim/hcn"
 	"encoding/json"
-	"github.com/Microsoft/windows-container-networking/test/container"
 )
 
 func GetVsidPol() []json.RawMessage {

--- a/test/utilities/connectivity_testing.go
+++ b/test/utilities/connectivity_testing.go
@@ -216,7 +216,6 @@ type PluginUnitTest struct {
 	NeedGW         bool
 }
 
-
 func (pt *PluginUnitTest) Create(netJson []byte, network *hcn.HostComputeNetwork, expectedPolicies []hcn.EndpointPolicy,
 	expectedSearch []string, expectedNameservers []string, cid string) {
 	pt.NetConfJson = netJson
@@ -363,9 +362,9 @@ func (pt *PluginUnitTest) RunBasicConnectivityTest(t *testing.T, numContainers i
 		}
 		ctList = append(ctList, ct)
 	}
-	
+
 	for i, ctx := range ctList {
-		if (i == 0) {
+		if i == 0 {
 			continue
 		}
 		err := ctList[0].RunContainerConnectivityTest(t, ctx.Endpoint.IpConfigurations[0].IpAddress)
@@ -373,7 +372,7 @@ func (pt *PluginUnitTest) RunBasicConnectivityTest(t *testing.T, numContainers i
 			t.Errorf("Failed Container Connectivity: %v", err)
 		}
 	}
-	
+
 	pt.Teardown(t)
 	for _, ct := range ctList {
 		ct.Teardown(t)

--- a/test/utilities/container_testing.go
+++ b/test/utilities/container_testing.go
@@ -8,21 +8,21 @@ import (
 )
 
 const (
-	ImageNano  = "mcr.microsoft.com/windows/nanoserver:1809"
-	ImageWsc   = "microsoft/windowsservercore"
+	ImageNano = "mcr.microsoft.com/windows/nanoserver:1809"
+	ImageWsc  = "microsoft/windowsservercore"
 )
 
 type ContainerInfo struct {
-	ContainerId    string	
-	Endpoint       *hcn.HostComputeEndpoint
-	Namespace      *hcn.HostComputeNamespace
-	Image          string
-	clean          func()
+	ContainerId string
+	Endpoint    *hcn.HostComputeEndpoint
+	Namespace   *hcn.HostComputeNamespace
+	Image       string
+	clean       func()
 }
 
 func (ci *ContainerInfo) Setup(t *testing.T) error {
 	ns := hcn.HostComputeNamespace{}
-	var err error 
+	var err error
 	ci.Namespace, err = ns.Create()
 	if err != nil {
 		t.Errorf("error while hcn namespace create: %v", err)
@@ -31,7 +31,7 @@ func (ci *ContainerInfo) Setup(t *testing.T) error {
 	ci.clean, err = contTest.CreateContainer(t, ci.ContainerId, ci.Image, ci.Namespace.Id)
 	return nil
 }
-func (ci *ContainerInfo) Teardown(t *testing.T) error {		
+func (ci *ContainerInfo) Teardown(t *testing.T) error {
 	ci.clean()
 	err := ci.Namespace.Delete()
 	if err != nil {


### PR DESCRIPTION
Previously we were erroring out on a failure or internal error. We now return the result properly with the error. Go Formatting Fixes. Enable Nat Test.