### PR TITLE
Add containerized golang build environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,6 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+# Build Outputs
+out/

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ OUTPUTDIR = out
 # Containerized build parameters.
 # Based on Azure/aks-engine Makefile
 REPO_PATH := github.com/Microsoft/windows-container-networking
-DEV_ENV_IMAGE := quay.io/deis/go-dev:v1.21.0
+DEV_ENV_IMAGE := golang:1.12.2
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_OPTS := --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_VARS}
 DEV_ENV_CMD := docker run ${DEV_ENV_OPTS} ${DEV_ENV_IMAGE}

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ OUTPUTDIR = out
 # Containerized build parameters.
 # Based on Azure/aks-engine Makefile
 REPO_PATH := github.com/Microsoft/windows-container-networking
-DEV_ENV_IMAGE := quay.io/deis/go-dev:v1.19.1
+DEV_ENV_IMAGE := quay.io/deis/go-dev:v1.21.0
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_OPTS := --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_VARS}
 DEV_ENV_CMD := docker run ${DEV_ENV_OPTS} ${DEV_ENV_IMAGE}

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,14 @@ CNI_NET_DIR = plugins
 OUTPUTDIR = out
 
 # Containerized build parameters.
-BUILD_CONTAINER_IMAGE = wcn-build
-BUILD_CONTAINER_NAME = wcn-builder
-BUILD_CONTAINER_REPO_PATH = /go/src/github.com
-BUILD_USER ?= $(shell id -u)
+# Based on Azure/aks-engine Makefile
+REPO_PATH := github.com/Microsoft/windows-container-networking
+DEV_ENV_IMAGE := quay.io/deis/go-dev:v1.19.1
+DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
+DEV_ENV_OPTS := --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_VARS}
+DEV_ENV_CMD := docker run ${DEV_ENV_OPTS} ${DEV_ENV_IMAGE}
+DEV_ENV_CMD_IT := docker run -it ${DEV_ENV_OPTS} ${DEV_ENV_IMAGE}
+DEV_CMD_RUN := docker run ${DEV_ENV_OPTS}
 
 # Docker plugin image parameters.
 
@@ -30,6 +34,12 @@ sdnbridge: $(OUTPUTDIR)/sdnbridge
 sdnoverlay: $(OUTPUTDIR)/sdnoverlay
 nat: $(OUTPUTDIR)/nat
 all: sdnbridge sdnoverlay nat
+
+# Containerized Build Environment
+.PHONY: dev
+dev:
+	$(DEV_ENV_CMD_IT) bash
+
 
 # Clean all build artifacts.
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -15,15 +15,20 @@ Currently you must build the binaries yourself (see below)
 * ToDo: Automated Release
 
 ## Build
-These plugins are made for windows and need to be compiled for windows
+These plugins are made for windows and need to be compiled for windows. However, you can cross-compile them from Linux.
 
 If you have make installed on your system:
 
-`make all` \ `make <plugin>`
+`make all` - will build `nat.exe`, `sdnbridge.exe` and `sdnoverlay.exe` 
+`make <plugin>`
 
 Else:
 
-`GOOS=windows GOARCH=amd64 go build -v -o out/<plugin>.exe plugins/<plugin>/*.go` 
+`GOOS=windows GOARCH=amd64 go build -v -o out/<plugin>.exe plugins/<plugin>/*.go`
+
+### Building inside a Linux container
+
+On a Linux machine, run `make dev`, then `make all`. That will cross-build the Windows binaries in a clean environment.
 
 ## Testing
 There is a test suite that should be run (`make test`) before any changes. Opening a PR should trigger a Jenkins run that will run all the tests. If you wish to run them locally, you'll need a nanoserver image pulled from docker. 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ These plugins are made for windows and need to be compiled for windows. However,
 
 If you have make installed on your system:
 
-`make all` - will build `nat.exe`, `sdnbridge.exe` and `sdnoverlay.exe` 
-`make <plugin>`
+`make all` - will build all plugins: `nat.exe`, `sdnbridge.exe`, and `sdnoverlay.exe`
+`make <plugin>` - will build an individual plugin
 
 Else:
 


### PR DESCRIPTION
This uses the same build environment used for [Azure/aks-engine](https://github.com/azure/aks-engine) among other projects.

The usage is simple `make dev`, `make all`. I prefer building this way because it avoids issues running multiple Golang versions and the need to change GOROOT/GOPATH between projects.