### PR TITLE
Fix cni config type.

### DIFF
--- a/cni/cni.go
+++ b/cni/cni.go
@@ -234,7 +234,7 @@ func (config *NetworkConfig) GetNetworkInfo(podNamespace string) *network.Networ
 	ninfo := &network.NetworkInfo{
 		ID:            config.Name,
 		Name:          config.Name,
-		Type:          network.NetworkType(config.Name),
+		Type:          network.NetworkType(config.Type),
 		Subnets:       subnets,
 		InterfaceName: "",
 		DNS:           dnsSettings,


### PR DESCRIPTION
Fix the network type.

The network type is set to a wrong value, hence it stops working.

Signed-off-by: Lantao Liu <lantaol@google.com>