### PR TITLE
Remove vendoring step from pipeline build to ensure the repo can be b…

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,8 +30,6 @@ steps:
 
 - script: |
     go version
-    go get -v -t -d ./...
-    make vendor
     make all
   workingDirectory: '$(modulePath)'
   displayName: 'Get dependencies, then build'


### PR DESCRIPTION
…uilt on clone. 

Added so we check whether theres a discrepancy between "go mod vendor" and the vendor folder, from a local standpoint.