### PR TITLE
Adding support for multiple CNI versions

### DIFF
--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -43,7 +43,7 @@ func (plugin *Plugin) Uninitialize() {
 // Execute executes the CNI command.
 func (plugin *Plugin) Execute(api PluginApi) error {
 	// Set supported CNI versions.
-	pluginInfo := cniVers.PluginSupports(Version)
+	pluginInfo := cniVers.PluginSupports(VersionsSupported...)
 
 	// Parse args and call the appropriate cmd handler.
 	cniErr := cniSkel.PluginMainWithError(api.Add, nil, api.Delete, pluginInfo, "CNI plugin WinCni")

--- a/common/core/network.go
+++ b/common/core/network.go
@@ -138,7 +138,13 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) (resultError error) {
 			// An endpoint already exists in the same network.
 			// Do not allow creation of more endpoints on same network
 			logrus.Debugf("[cni-net] Endpoint exists on same network, ignoring add : [%v].", epInfo)
-			result := cni.GetResult020(nwConfig, hnsEndpoint)
+			// Convert result to the requested CNI version.
+			res := cni.GetCurrResult(nwConfig, hnsEndpoint, args.IfName)
+			result, err := res.GetAsVersion(cniConfig.CniVersion)
+			if err != nil {
+				return err
+			}
+
 			result.Print()
 			return nil
 		}
@@ -175,7 +181,14 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) (resultError error) {
 		return err
 	}
 
-	result := cni.GetResult020(nwConfig, epInfo)
+	// Convert result to the requested CNI version.
+	res := cni.GetCurrResult(nwConfig, epInfo, args.IfName)
+	result, err := res.GetAsVersion(cniConfig.CniVersion)
+	if err != nil {
+		return err
+	}
+
+	//	result := cni.GetResult020(nwConfig, epInfo)
 	result.Print()
 	logrus.Debugf("[cni-net] result: %v", result.String())
 	return nil


### PR DESCRIPTION
This adds support for version 0.3.0 as well as the currently supported 0.2.0 version. This is required to be able to support cni chaining via cni.conflist that was introduced in 0.3.0.