### PR TITLE
Initial changes for ipv6 support for l2bridge network

### DIFF
--- a/cni/cni.go
+++ b/cni/cni.go
@@ -319,7 +319,7 @@ func (config *NetworkConfig) GetEndpointInfo(
 		epInfo.Subnet = networkInfo.Subnets[0].AddressPrefix
 		// Gateway field (below) will be updated to the ipam allocated value
 		// (if applicable) in allocateIpam
-		// The Gateway6 field (ipv6 gatweay) is not derived like this and
+		// The Gateway6 field (ipv6 gateway) is not derived like this and
 		// must be supplied through the ipam.
 		epInfo.Gateway = networkInfo.Subnets[0].GatewayAddress
 	}
@@ -365,52 +365,50 @@ func GetCurrResult(network *network.NetworkInfo, endpoint *network.EndpointInfo,
 		var ip = GetIP(network, endpoint)
 		ip.InterfaceIndex = 0
 			
-    	cIP := cniTypesCurr.IPConfig{
-	    	Version: ip.Version,
-		    Address: net.IPNet{
-			    IP:   ip.Address.IP,
-    			Mask: ip.Address.Mask},
-	    	Gateway:   ip.Gateway,
-		    Interface: &ip.InterfaceIndex,
-	    }
-	    result.IPs = append(result.IPs, &cIP)
+		cIP := cniTypesCurr.IPConfig{
+				Version: ip.Version,
+				Address: net.IPNet{
+					IP:		ip.Address.IP,
+					Mask:	ip.Address.Mask},
+				Gateway: ip.Gateway,
+				Interface: &ip.InterfaceIndex,
+		}
 
-    } else {
+		result.IPs = append(result.IPs, &cIP)
 
-    	ip4, ip6 := GetDualStackAddresses(endpoint)
+	} else {
 
-    	if ip4  != nil {
+		ip4, ip6 := GetDualStackAddresses(endpoint)
 
-			ip4.InterfaceIndex = 0
+		ip4.InterfaceIndex = 0
 
-	    	cIP4 := cniTypesCurr.IPConfig{
-		    	Version: ip4.Version,
-			    Address: net.IPNet{
-				    IP:   ip4.Address.IP,
-				    Mask: ip4.Address.Mask},
-    			Gateway:   ip4.Gateway,
-	    		Interface: &ip4.InterfaceIndex,
-		    }
+		cIP4 := cniTypesCurr.IPConfig{
+				Version: ip4.Version,
+				Address: net.IPNet{
+					IP:		ip4.Address.IP,
+					Mask:	ip4.Address.Mask},
+				Gateway: ip4.Gateway,
+				Interface: &ip4.InterfaceIndex,
+		}
 	
-    		result.IPs = append(result.IPs, &cIP4)
-    	}
+		result.IPs = append(result.IPs, &cIP4)
 
-    	if ip6  != nil {
+		if ip6  != nil {
 
 			ip6.InterfaceIndex = 0
 
-	    	cIP6 := cniTypesCurr.IPConfig{
-		    	Version: ip6.Version,
-			    Address: net.IPNet{
-				    IP:   ip6.Address.IP,
-				    Mask: ip6.Address.Mask},
-    			Gateway:   ip6.Gateway,
-	    		Interface: &ip6.InterfaceIndex,
-		    }
+			cIP6 := cniTypesCurr.IPConfig{
+					Version: ip6.Version,
+					Address: net.IPNet{
+						IP:		ip6.Address.IP,
+						Mask:	ip6.Address.Mask},
+					Gateway:	ip6.Gateway,
+					Interface: &ip6.InterfaceIndex,
+			}
 	
-    		result.IPs = append(result.IPs, &cIP6)
-    	}
-    }
+			result.IPs = append(result.IPs, &cIP6)
+		}
+	}
 
 	// Add Interfaces to result.
 	iface := &cniTypesCurr.Interface{
@@ -443,18 +441,15 @@ func GetDualStackAddresses(endpoint *network.EndpointInfo) (*IP, *IP) {
 	var ip4 *IP
 	var ip6 *IP
 	
-	if endpoint.IPAddress != nil {
+	ip4address := net.IPNet{}
+	ip4address.IP = endpoint.IPAddress
+ 	ip4address.Mask = endpoint.IP4Mask
 
-		ip4address := net.IPNet{}
-		ip4address.IP = endpoint.IPAddress
- 		ip4address.Mask = endpoint.IP4Mask
-
-		ip4 = &IP{
-			Version: "4",
-			Address: cniTypes.IPNet(ip4address),
-			Gateway: endpoint.Gateway,
-			InterfaceIndex: 0,
-		}
+	ip4 = &IP{
+		Version: "4",
+		Address: cniTypes.IPNet(ip4address),
+		Gateway: endpoint.Gateway,
+		InterfaceIndex: 0,
 	}
 
 	if endpoint.IPAddress6.IP != nil {

--- a/common/utils.go
+++ b/common/utils.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"net"
+	"strconv"
 
 	"github.com/sirupsen/logrus"
 )
@@ -21,4 +22,10 @@ func LogNetworkInterfaces() {
 		addrs, _ := iface.Addrs()
 		logrus.Debugf("[net] Network interface: %+v with IP addresses: %+v", iface, addrs)
 	}
+}
+
+func GetAddressAsCidr(ip string, prefix uint8) string {
+
+    return ip + string('/') + strconv.FormatUint(uint64(prefix), 10)
+
 }

--- a/example/l2bridgedualstack_host-local_ipam.conf
+++ b/example/l2bridgedualstack_host-local_ipam.conf
@@ -1,0 +1,96 @@
+{
+    "cniVersion": "0.2.0",
+    "name": "winl2bridge",
+    "type": "sdnbridge",
+    "master": "Ethernet",
+    "capabilities": {
+        "portMappings": true,
+        "dnsCapabilities": true
+    },
+    "optionalFlags": {
+        "localRoutedPortMapping": true,
+        "allowAclPortMapping": true,
+        "enableDualStack": true
+    },
+    "ipam": {
+        "type": "host-local",
+        "ranges": [
+            [
+                {
+                    "subnet": "192.168.1.0/24",
+                    "rangeStart": "192.168.1.10",
+                    "rangeEnd": "192.168.1.50",
+                    "gateway": "192.168.1.2"
+                }
+            ],
+            [
+                {
+                    "subnet": "fd00::100/120",
+                    "rangeStart": "fd00::102",
+                    "rangeEnd": "fd00::1fe",
+                    "gateway": "fd00::101"
+                }
+            ]
+        ]
+    },
+    "dns": {
+        "Nameservers": [
+            "10.127.130.7"
+        ],
+        "Search": [
+            "svc.cluster.local"
+        ]
+    },
+    "AdditionalArgs": [
+        {
+            "Name": "EndpointPolicy",
+            "Value": {
+                "Type": "OutBoundNAT",
+                "Settings": {
+                    "Exceptions": [
+                        "192.168.0.0/16",
+                        "11.0.0.0/8",
+                        "10.124.24.0/23"
+                    ]
+                }
+            }
+        },
+        {
+            "Name": "EndpointPolicy",
+            "Value": {
+                "Type": "OutBoundNAT",
+                "Settings": {
+                    "VirtualIP": "fc00::123",
+                    "Destinations": [
+                        "fd01::192",
+                        "fd01::193"
+                    ],
+                    "Exceptions": [
+                        "fd03::100/120",
+                        "fd04::100/120"
+                    ]
+                }
+            }
+        },
+        {
+            "Name": "EndpointPolicy",
+            "Value": {
+                "Type": "SDNRoute",
+                "Settings": {
+                    "DestinationPrefix": "11.0.0.0/8",
+                    "NeedEncap": true
+                }
+            }
+        },
+        {
+            "Name": "EndpointPolicy",
+            "Value": {
+                "Type": "SDNRoute",
+                "Settings": {
+                    "DestinationPrefix": "fd00::200/120",
+                    "NeedEncap": true
+                }
+            }
+        }
+    ]
+}

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -6,6 +6,7 @@ package network
 import (
 	"encoding/json"
 	"net"
+	"github.com/Microsoft/windows-container-networking/common"
 
 	"github.com/Microsoft/hcsshim/hcn"
 )
@@ -18,13 +19,17 @@ type EndpointInfo struct {
 	NetworkID   string
 	NamespaceID string
 	IPAddress   net.IP
+	IP4Mask     net.IPMask // Used when dual stack is enabled
+	IPAddress6  net.IPNet
 	MacAddress  net.HardwareAddr
 	Gateway     net.IP
+	Gateway6    net.IP
 	Routes      []RouteInfo
 	Policies    []Policy
 	Subnet      net.IPNet
 	DNS         DNSInfo
 	ContainerID string
+	DualStack   bool
 }
 
 // RouteInfo contains information about an IP route.
@@ -38,20 +43,45 @@ func (endpoint *EndpointInfo) GetHostComputeEndpoint() *hcn.HostComputeEndpoint 
 	// Check for nil on address objects.
 	ipAddr := ""
 	ipConfig := []hcn.IpConfig{}
+	routes := []hcn.Route{}	
+
 	if endpoint.IPAddress != nil {
 		ipAddr = endpoint.IPAddress.String()
 		ipConfig = append(ipConfig, hcn.IpConfig{
 			IpAddress: ipAddr,
 		})
 	}
+
+	if endpoint.IPAddress6.IP != nil {
+		ipAddr = endpoint.IPAddress6.IP.String()
+		ipConfig = append(ipConfig, hcn.IpConfig{
+			IpAddress: ipAddr,
+		})
+	}
+
 	macAddr := ""
 	if endpoint.MacAddress != nil {
 		macAddr = endpoint.MacAddress.String()
 	}
+
 	gwAddr := ""
 	if endpoint.Gateway != nil {
 		gwAddr = endpoint.Gateway.String()
 	}
+
+	routes = append(routes, hcn.Route{
+		NextHop:           gwAddr,
+		DestinationPrefix: "0.0.0.0/0",
+	})
+
+	if endpoint.Gateway6 != nil {
+		gwAddr6 := endpoint.Gateway6.String()
+		routes = append(routes, hcn.Route{
+			NextHop:           gwAddr6,
+			DestinationPrefix: "::/0",
+		})
+	}
+
 	return &hcn.HostComputeEndpoint{
 		Name:                 endpoint.Name,
 		Id:                   endpoint.ID,
@@ -64,12 +94,7 @@ func (endpoint *EndpointInfo) GetHostComputeEndpoint() *hcn.HostComputeEndpoint 
 			Options:    endpoint.DNS.Options,
 		},
 		MacAddress: macAddr,
-		Routes: []hcn.Route{
-			{
-				NextHop:           gwAddr,
-				DestinationPrefix: "0.0.0.0/0",
-			},
-		},
+		Routes: routes,
 		IpConfigurations: ipConfig,
 		SchemaVersion: hcn.SchemaVersion{
 			Major: 2,
@@ -80,17 +105,71 @@ func (endpoint *EndpointInfo) GetHostComputeEndpoint() *hcn.HostComputeEndpoint 
 }
 
 // GetEndpointInfoFromHostComputeEndpoint converts HostComputeEndpoint to CNI EndpointInfo.
-func GetEndpointInfoFromHostComputeEndpoint(hcnEndpoint *hcn.HostComputeEndpoint) *EndpointInfo {
+func GetEndpointInfoFromHostComputeEndpoint(hcnEndpoint *hcn.HostComputeEndpoint, withIpv6 bool) *EndpointInfo {
 	// Ignore empty MAC, GW, and IP.
 	macAddr, _ := net.ParseMAC(hcnEndpoint.MacAddress)
 	var gwAddr net.IP
-	if len(hcnEndpoint.Routes) > 0 {
-		gwAddr = net.ParseIP(hcnEndpoint.Routes[0].NextHop)
+	var gwAddr6 net.IP	
+	var ipAddr4 net.IPNet
+	var ipAddr6 net.IPNet
+
+	if withIpv6 == false {
+
+		if len(hcnEndpoint.Routes) > 0 {
+			gwAddr = net.ParseIP(hcnEndpoint.Routes[0].NextHop)
+		}
+			
+	    if len(hcnEndpoint.IpConfigurations) > 0 {
+		    ipAddr4.IP = net.ParseIP(hcnEndpoint.IpConfigurations[0].IpAddress)
+	    }
+    } else {
+		var ip4found bool
+		var ip6found bool
+
+		for _, addr := range hcnEndpoint.IpConfigurations {
+			if net.ParseIP(addr.IpAddress).To4() == nil &&
+			   ip6found == false {
+				ip, mask, _ := net.ParseCIDR(common.GetAddressAsCidr(addr.IpAddress, addr.PrefixLength))
+				ipAddr6.IP = ip
+				ipAddr6.Mask = mask.Mask
+				ip6found = true
+			} else {
+				if ip4found == false {
+				    ip, mask, _ := net.ParseCIDR(common.GetAddressAsCidr(addr.IpAddress, addr.PrefixLength))
+   		    	    ipAddr4.IP = ip
+	    	    	ipAddr4.Mask = mask.Mask
+				    ip4found = true
+				}
+			}
+
+			if ip4found && ip6found {
+				break
+			}
+		}
+
+		ip4found = false
+		ip6found = false
+
+		for _, r := range hcnEndpoint.Routes {
+
+			if net.ParseIP(r.NextHop).To4() == nil &&
+			   ip6found == false {
+				gwAddr6 = net.ParseIP(r.NextHop)
+				ip6found = true
+			} else {
+				if ip4found == false {
+    				gwAddr = net.ParseIP(r.NextHop)
+	    			ip4found = true
+				}
+			}
+
+			if ip4found && ip6found {
+				break
+			}
+
+		}
 	}
-	var ipAddr net.IP
-	if len(hcnEndpoint.IpConfigurations) > 0 {
-		ipAddr = net.ParseIP(hcnEndpoint.IpConfigurations[0].IpAddress)
-	}
+
 	return &EndpointInfo{
 		Name:        hcnEndpoint.Name,
 		ID:          hcnEndpoint.Id,
@@ -104,9 +183,13 @@ func GetEndpointInfoFromHostComputeEndpoint(hcnEndpoint *hcn.HostComputeEndpoint
 		},
 		MacAddress: macAddr,
 		Gateway:    gwAddr,
-		IPAddress:  ipAddr,
+		IPAddress:  ipAddr4.IP,
+		IP4Mask: ipAddr4.Mask,
+		Gateway6: gwAddr6,
+		IPAddress6: ipAddr6,		
 		Policies:   GetEndpointPoliciesFromHostComputePolicies(hcnEndpoint.Policies),
 	}
+
 }
 
 // GetEndpointPoliciesFromHostComputePolicies converts HCN Endpoint policy into CNI Policy objects.

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -181,13 +181,13 @@ func GetEndpointInfoFromHostComputeEndpoint(hcnEndpoint *hcn.HostComputeEndpoint
 			Nameservers: hcnEndpoint.Dns.ServerList,
 			Options:     hcnEndpoint.Dns.Options,
 		},
-		MacAddress: macAddr,
-		Gateway:    gwAddr,
-		IPAddress:  ipAddr4.IP,
-		IP4Mask: ipAddr4.Mask,
-		Gateway6: gwAddr6,
-		IPAddress6: ipAddr6,		
-		Policies:   GetEndpointPoliciesFromHostComputePolicies(hcnEndpoint.Policies),
+		MacAddress:  macAddr,
+		Gateway:     gwAddr,
+		IPAddress:   ipAddr4.IP,
+		IP4Mask:     ipAddr4.Mask,
+		Gateway6:    gwAddr6,
+		IPAddress6:  ipAddr6,		
+		Policies:    GetEndpointPoliciesFromHostComputePolicies(hcnEndpoint.Policies),
 	}
 
 }

--- a/network/manager.go
+++ b/network/manager.go
@@ -31,8 +31,8 @@ type Manager interface {
 	// Endpoint
 	CreateEndpoint(networkID string, epInfo *EndpointInfo, namespaceID string) (*EndpointInfo, error)
 	DeleteEndpoint(endpointID string) error
-	GetEndpoint(endpointID string) (*EndpointInfo, error)
-	GetEndpointByName(endpointName string) (*EndpointInfo, error)
+	GetEndpoint(endpointID string, withIpv6 bool) (*EndpointInfo, error)
+	GetEndpointByName(endpointName string, withIpv6 bool) (*EndpointInfo, error)
 }
 
 // NewManager creates a new networkManager.
@@ -118,6 +118,7 @@ func (nm *networkManager) GetNetworkByName(networkName string) (*NetworkInfo, er
 
 // CreateEndpoint creates a new container endpoint.
 func (nm *networkManager) CreateEndpoint(networkID string, epInfo *EndpointInfo, namespaceID string) (*EndpointInfo, error) {
+
 	nm.Lock()
 	defer nm.Unlock()
 
@@ -134,7 +135,7 @@ func (nm *networkManager) CreateEndpoint(networkID string, epInfo *EndpointInfo,
 		return nil, fmt.Errorf("error adding endpoint to namespace %v : endpoint %v", err, hcnEndpoint)
 	}
 
-	return GetEndpointInfoFromHostComputeEndpoint(hcnEndpoint), err
+	return GetEndpointInfoFromHostComputeEndpoint(hcnEndpoint, epInfo.DualStack), err
 }
 
 // DeleteEndpoint deletes an existing container endpoint.
@@ -185,7 +186,7 @@ func (nm *networkManager) DeleteEndpoint(endpointID string) error {
 }
 
 // GetEndpoint returns the endpoint matching the Id.
-func (nm *networkManager) GetEndpoint(endpointID string) (*EndpointInfo, error) {
+func (nm *networkManager) GetEndpoint(endpointID string, withIpv6 bool) (*EndpointInfo, error) {
 	nm.Lock()
 	defer nm.Unlock()
 
@@ -194,11 +195,11 @@ func (nm *networkManager) GetEndpoint(endpointID string) (*EndpointInfo, error) 
 		return nil, err
 	}
 
-	return GetEndpointInfoFromHostComputeEndpoint(hcnEndpoint), nil
+	return GetEndpointInfoFromHostComputeEndpoint(hcnEndpoint, withIpv6), nil
 }
 
 // GetEndpointByName returns the endpoint matching the Name.
-func (nm *networkManager) GetEndpointByName(endpointName string) (*EndpointInfo, error) {
+func (nm *networkManager) GetEndpointByName(endpointName string, withIpv6 bool) (*EndpointInfo, error) {
 	nm.Lock()
 	defer nm.Unlock()
 
@@ -207,5 +208,5 @@ func (nm *networkManager) GetEndpointByName(endpointName string) (*EndpointInfo,
 		return nil, err
 	}
 
-	return GetEndpointInfoFromHostComputeEndpoint(hcnEndpoint), nil
+	return GetEndpointInfoFromHostComputeEndpoint(hcnEndpoint, withIpv6), nil
 }


### PR DESCRIPTION
Initial changes to support ipv6. The support is as follows:
-Only l2bridge network is supported.
-The support is off by default and enabled when the enableDualStack in optionalFlags is set to true.
-1 ipv4 and 1 ipv6 address per endpoint would be supported.
-The network must be created beforehand when optionalFlags is true. The CNI will not attempt to create the network.
-The CNI relies entirely on the ipam for configuration of subnet, routes, default gateway etc. when enableDualStack is true and this behavior is applicable for both ipv6 and ipv4. Note this might cause subtle changes in behavior for ipv4 when enableDualStack is not true.
-The result of the final endpoint configuration will be derived from the results returned by HNS.
-The CNI will not attempt to verify if the policy being applied is supported on Windows by HNS. This validation is entirely left to HNS.