### PR TITLE
Handle nil pointer if HNS network not created

### DIFF
--- a/common/core/network.go
+++ b/common/core/network.go
@@ -147,11 +147,17 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) (resultError error) {
 		// The network must be created beforehand
 		nwConfig, err = plugin.nm.GetNetworkByName(cniConfig.Name)
 
+		if err != nil {
+			logrus.Errorf("[cni-net] network not created for %s", cniConfig.Name)
+			return err
+		}
+
 		if nwConfig.Type != network.L2Bridge {
 			logrus.Errorf("[cni-net] Dual stack can only be specified with l2bridge network: [%v].", nwConfig.Type)
-			return errors.New("Dual stack specified with non l2bridge network")	
+			return errors.New("Dual stack specified with non l2bridge network")
 		}
 	}
+
 	if err != nil {
 		return err
 	}
@@ -255,26 +261,26 @@ func addEndpointGatewaysFromConfig(
 			if endpointInfo.Gateway == nil {
 
 				logrus.Debugf("[cni-net] Found no ipv4 gateway")
-				
+
 				m1, _ := addr.Dst.Mask.Size()
 				m2, _ := defaultDestipv4Network.Mask.Size()
 
 				if m1 == m2 &&
-				   addr.Dst.IP.Equal(defaultDestipv4) {
+					addr.Dst.IP.Equal(defaultDestipv4) {
 					endpointInfo.Gateway = addr.GW
 					logrus.Debugf("[cni-net] Assigned % as ipv4 gateway", endpointInfo.Gateway.String())
 				}
 			}
 		} else {
 			if endpointInfo.Gateway6 == nil {
-				
+
 				logrus.Debugf("[cni-net] Found no ipv6 gateway")
 
 				m1, _ := addr.Dst.Mask.Size()
 				m2, _ := defaultDestipv6Network.Mask.Size()
 
 				if m1 == m2 &&
-				   addr.Dst.IP.Equal(defaultDestipv6) {
+					addr.Dst.IP.Equal(defaultDestipv6) {
 					endpointInfo.Gateway6 = addr.GW
 					logrus.Debugf("[cni-net] Assigned % as ipv6 gateway", endpointInfo.Gateway6.String())
 				}


### PR DESCRIPTION
I got the error below and wanted to handle it a little better. It took me awhile to figure out why this was happening. I don't believe the error returned from 'GetNetworkByName' is super user friendly. I can return a useful error message if desired. 


Stack trace:

        // time="2022-07-14T03:31:57Z" level=fatal msg="run pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox \"1a690258599b6a720007e10571d4ff5b1c46b03f11d34386a3120dd2af7412ef\": plugin type=\"sdnbridge\" name=\"winl2bridgetest\" failed (add): netplugin failed: \"panic: runtime error: invalid memory address or nil pointer dereference\\n[signal 0xc0000005 code=0x0 addr=0x20 pc=0x8b8975]\\n\\ngoroutine 1 [running]:\\ngithub.com/Microsoft/windows-container-networking/common/core.(*netPlugin).Add(0xc000094900, 0xc00005c150, 0x0, 0x0)\\n\\t/home/debjit/goroot/src/github.com/microsoft/windows-container-networking/common/core/network.go:150 +0x655\\ngithub.com/containernetworking/cni/pkg/skel.(*dispatcher).checkVersionAndCall(0xc00025fe58, 0xc00005c150, 0x9b2440, 0xc000048510, 0xc00025fe40, 0xc000048510)\\n\\t/home/debjit/goroot/src/github.com/microsoft/windows-container-networking/vendor/github.com/containernetworking/cni/pkg/skel/skel.go:166 +0x2c4\\ngithub.com/containernetworking/cni/pkg/skel.(*dispatcher).pluginMain(0xc00025fe58, 0xc00025fe40, 0x0, 0xc00025fe28, 0x9b2440, 0xc000048510, 0x95331c, 0x11, 0xc0001511f0)\\n\\t/home/debjit/goroot/src/github.com/microsoft/windows-container-networking/vendor/github.com/containernetworking/cni/pkg/skel/skel.go:218 +0x428\\ngithub.com/containernetworking/cni/pkg/skel.PluginMainWithError(...)\\n\\t/home/debjit/goroot/src/github.com/microsoft/windows-container-networking/vendor/github.com/containernetworking/cni/pkg/skel/skel.go:275\\ngithub.com/Microsoft/windows-container-networking/cni.(*Plugin).Execute(0xc0000c8050, 0x9b2400, 0xc000094900, 0x0, 0xc0000c8048)\\n\\t/home/debjit/goroot/src/github.com/microsoft/windows-container-networking/cni/plugin.go:49 +0x1f8\\ngithub.com/Microsoft/windows-container-networking/common/core.Core()\\n\\t/home/debjit/goroot/src/github.com/microsoft/windows-container-networking/common/core/core.go:50 +0x2e5\\nmain.main()\\n\\t/home/debjit/goroot/src/github.com/microsoft/windows-container-networking/plugins/sdnbridge/sdnbridge_windows.go:16 +0x27\\n\""