### PR TITLE
QA: update code for golangci-lint and run `go fmt`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,6 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Lint
-        # TODO(aznashwan): codebase currently has linter issues to be solved in a later PR.
-        continue-on-error: true
         uses: golangci/golangci-lint-action@v3
         with:
           working-directory: src/github.com/Microsoft/windows-container-networking

--- a/cni/cni.go
+++ b/cni/cni.go
@@ -105,16 +105,16 @@ type K8SPodEnvArgs struct {
 }
 
 type OptionalFlags struct {
-	LocalRoutePortMapping bool `json:"localRoutedPortMapping"`
-	AllowAclPortMapping   bool `json:"allowAclPortMapping"`
-	ForceBridgeGateway    bool `json:"forceBridgeGateway"` // Intended to be temporary workaround
-	EnableDualStack       bool `json:"enableDualStack"`
-	LoopbackDSR           bool `json:"loopbackDSR"`
-	GatewayFromAdditionalRoutes    bool `json:"gatewayFromAdditionalRoutes"`
+	LocalRoutePortMapping       bool `json:"localRoutedPortMapping"`
+	AllowAclPortMapping         bool `json:"allowAclPortMapping"`
+	ForceBridgeGateway          bool `json:"forceBridgeGateway"` // Intended to be temporary workaround
+	EnableDualStack             bool `json:"enableDualStack"`
+	LoopbackDSR                 bool `json:"loopbackDSR"`
+	GatewayFromAdditionalRoutes bool `json:"gatewayFromAdditionalRoutes"`
 }
 
 func (r *Result) Print() {
-	fmt.Printf(r.String())
+	fmt.Printf("%s", r.String())
 }
 
 func (r *Result) String() string {
@@ -369,7 +369,7 @@ func GetCurrResult(network *network.NetworkInfo, endpoint *network.EndpointInfo,
 
 	var iFace = GetInterface(endpoint)
 
-	if cniConfig.OptionalFlags.EnableDualStack == false {
+	if !cniConfig.OptionalFlags.EnableDualStack {
 
 		var ip = GetIP(network, endpoint)
 		ip.InterfaceIndex = 0

--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -31,8 +31,7 @@ func NewPlugin(name, version string) (*Plugin, error) {
 // Initialize initializes the plugin.
 func (plugin *Plugin) Initialize(config *common.PluginConfig) error {
 	// Initialize the base plugin.
-	plugin.Plugin.Initialize(config)
-	return nil
+	return plugin.Plugin.Initialize(config)
 }
 
 // Uninitialize uninitializes the plugin.

--- a/common/core/network.go
+++ b/common/core/network.go
@@ -114,7 +114,7 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) (resultError error) {
 
 	logrus.Debugf("[cni-net] Read network configuration %+v.", cniConfig)
 
-	if cniConfig.OptionalFlags.EnableDualStack == false {
+	if !cniConfig.OptionalFlags.EnableDualStack {
 		logrus.Infof("[cni-net] Dual stack is disabled")
 	} else {
 		logrus.Infof("[cni-net] Dual stack is enabled")
@@ -141,7 +141,7 @@ func (plugin *netPlugin) Add(args *cniSkel.CmdArgs) (resultError error) {
 		return errors.New("cannot create endpoint without a namespace")
 	}
 
-	if cniConfig.OptionalFlags.EnableDualStack == false {
+	if !cniConfig.OptionalFlags.EnableDualStack {
 		nwConfig, err = getOrCreateNetwork(plugin, networkInfo, cniConfig)
 	} else {
 		// The network must be created beforehand
@@ -259,8 +259,7 @@ func addEndpointGatewaysFromConfig(
 				m1, _ := addr.Dst.Mask.Size()
 				m2, _ := defaultDestipv4Network.Mask.Size()
 
-				if m1 == m2 &&
-					addr.Dst.IP.Equal(defaultDestipv4) {
+				if m1 == m2 && addr.Dst.IP.Equal(defaultDestipv4) {
 					endpointInfo.Gateway = addr.GW
 					logrus.Debugf("[cni-net] Assigned %v as ipv4 gateway", endpointInfo.Gateway.String())
 				}
@@ -273,8 +272,7 @@ func addEndpointGatewaysFromConfig(
 				m1, _ := addr.Dst.Mask.Size()
 				m2, _ := defaultDestipv6Network.Mask.Size()
 
-				if m1 == m2 &&
-					addr.Dst.IP.Equal(defaultDestipv6) {
+				if m1 == m2 && addr.Dst.IP.Equal(defaultDestipv6) {
 					endpointInfo.Gateway6 = addr.GW
 					logrus.Debugf("[cni-net] Assigned %v as ipv6 gateway", endpointInfo.Gateway6.String())
 				}
@@ -298,7 +296,7 @@ func allocateIpam(
 	var resultImpl *cniTypesImpl.Result
 	var err error
 
-	if cniConfig.OptionalFlags.EnableDualStack == false {
+	if !cniConfig.OptionalFlags.EnableDualStack {
 		// It seems the right thing would be to pass the original byte stream instead of the one
 		// which cni parsed into NetworkConfig. However to preserve compatibility continue
 		// the current behavior when dual stack is not enabled
@@ -319,7 +317,7 @@ func allocateIpam(
 	}
 
 	logrus.Debugf("[cni-net] IPAM plugin returned result %v.", resultImpl)
-	if cniConfig.OptionalFlags.EnableDualStack == false {
+	if !cniConfig.OptionalFlags.EnableDualStack {
 		// Derive the subnet from allocated IP address.
 		if resultImpl.IP4 != nil {
 			var subnetInfo = network.SubnetInfo{
@@ -331,7 +329,7 @@ func allocateIpam(
 			endpointInfo.IPAddress = resultImpl.IP4.IP.IP
 			endpointInfo.Gateway = resultImpl.IP4.Gateway
 
-			if forceBridgeGateway == true {
+			if forceBridgeGateway {
 				endpointInfo.Gateway = resultImpl.IP4.IP.IP.Mask(resultImpl.IP4.IP.Mask)
 				endpointInfo.Gateway[3] = 2
 			}
@@ -350,7 +348,7 @@ func allocateIpam(
 			endpointInfo.IP4Mask = resultImpl.IP4.IP.Mask
 			endpointInfo.Gateway = resultImpl.IP4.Gateway
 
-			if forceBridgeGateway == true {
+			if forceBridgeGateway {
 				endpointInfo.Gateway = resultImpl.IP4.IP.IP.Mask(resultImpl.IP4.IP.Mask)
 				endpointInfo.Gateway[3] = 2
 			}
@@ -379,7 +377,7 @@ func allocateIpam(
 // deallocateIpam performs the cleanup necessary for removing an ipam
 func deallocateIpam(cniConfig *cni.NetworkConfig, networkConfByteStream []byte) error {
 
-	if cniConfig.OptionalFlags.EnableDualStack == false {
+	if !cniConfig.OptionalFlags.EnableDualStack {
 		logrus.Infof("[cni-net] Delete from ipam when dual stack is disabled")
 		return invoke.DelegateDel(context.TODO(), cniConfig.Ipam.Type, cniConfig.Serialize(), nil)
 	} else {

--- a/common/utils.go
+++ b/common/utils.go
@@ -26,6 +26,6 @@ func LogNetworkInterfaces() {
 
 func GetAddressAsCidr(ip string, prefix uint8) string {
 
-    return ip + string('/') + strconv.FormatUint(uint64(prefix), 10)
+	return ip + string('/') + strconv.FormatUint(uint64(prefix), 10)
 
 }

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -5,8 +5,8 @@ package network
 
 import (
 	"encoding/json"
-	"net"
 	"github.com/Microsoft/windows-container-networking/common"
+	"net"
 
 	"github.com/Microsoft/hcsshim/hcn"
 )
@@ -43,7 +43,7 @@ func (endpoint *EndpointInfo) GetHostComputeEndpoint() *hcn.HostComputeEndpoint 
 	// Check for nil on address objects.
 	ipAddr := ""
 	ipConfig := []hcn.IpConfig{}
-	routes := []hcn.Route{}	
+	routes := []hcn.Route{}
 
 	if endpoint.IPAddress != nil {
 		ipAddr = endpoint.IPAddress.String()
@@ -93,8 +93,8 @@ func (endpoint *EndpointInfo) GetHostComputeEndpoint() *hcn.HostComputeEndpoint 
 			ServerList: endpoint.DNS.Nameservers,
 			Options:    endpoint.DNS.Options,
 		},
-		MacAddress: macAddr,
-		Routes: routes,
+		MacAddress:       macAddr,
+		Routes:           routes,
 		IpConfigurations: ipConfig,
 		SchemaVersion: hcn.SchemaVersion{
 			Major: 2,
@@ -109,36 +109,35 @@ func GetEndpointInfoFromHostComputeEndpoint(hcnEndpoint *hcn.HostComputeEndpoint
 	// Ignore empty MAC, GW, and IP.
 	macAddr, _ := net.ParseMAC(hcnEndpoint.MacAddress)
 	var gwAddr net.IP
-	var gwAddr6 net.IP	
+	var gwAddr6 net.IP
 	var ipAddr4 net.IPNet
 	var ipAddr6 net.IPNet
 
-	if withIpv6 == false {
+	if !withIpv6 {
 
 		if len(hcnEndpoint.Routes) > 0 {
 			gwAddr = net.ParseIP(hcnEndpoint.Routes[0].NextHop)
 		}
-			
-	    if len(hcnEndpoint.IpConfigurations) > 0 {
-		    ipAddr4.IP = net.ParseIP(hcnEndpoint.IpConfigurations[0].IpAddress)
-	    }
-    } else {
+
+		if len(hcnEndpoint.IpConfigurations) > 0 {
+			ipAddr4.IP = net.ParseIP(hcnEndpoint.IpConfigurations[0].IpAddress)
+		}
+	} else {
 		var ip4found bool
 		var ip6found bool
 
 		for _, addr := range hcnEndpoint.IpConfigurations {
-			if net.ParseIP(addr.IpAddress).To4() == nil &&
-			   ip6found == false {
+			if net.ParseIP(addr.IpAddress).To4() == nil && !ip6found {
 				ip, mask, _ := net.ParseCIDR(common.GetAddressAsCidr(addr.IpAddress, addr.PrefixLength))
 				ipAddr6.IP = ip
 				ipAddr6.Mask = mask.Mask
 				ip6found = true
 			} else {
-				if ip4found == false {
-				    ip, mask, _ := net.ParseCIDR(common.GetAddressAsCidr(addr.IpAddress, addr.PrefixLength))
-   		    	    ipAddr4.IP = ip
-	    	    	ipAddr4.Mask = mask.Mask
-				    ip4found = true
+				if !ip4found {
+					ip, mask, _ := net.ParseCIDR(common.GetAddressAsCidr(addr.IpAddress, addr.PrefixLength))
+					ipAddr4.IP = ip
+					ipAddr4.Mask = mask.Mask
+					ip4found = true
 				}
 			}
 
@@ -152,14 +151,13 @@ func GetEndpointInfoFromHostComputeEndpoint(hcnEndpoint *hcn.HostComputeEndpoint
 
 		for _, r := range hcnEndpoint.Routes {
 
-			if net.ParseIP(r.NextHop).To4() == nil &&
-			   ip6found == false {
+			if net.ParseIP(r.NextHop).To4() == nil && !ip6found {
 				gwAddr6 = net.ParseIP(r.NextHop)
 				ip6found = true
 			} else {
-				if ip4found == false {
-    				gwAddr = net.ParseIP(r.NextHop)
-	    			ip4found = true
+				if !ip4found {
+					gwAddr = net.ParseIP(r.NextHop)
+					ip4found = true
 				}
 			}
 
@@ -181,13 +179,13 @@ func GetEndpointInfoFromHostComputeEndpoint(hcnEndpoint *hcn.HostComputeEndpoint
 			Nameservers: hcnEndpoint.Dns.ServerList,
 			Options:     hcnEndpoint.Dns.Options,
 		},
-		MacAddress:  macAddr,
-		Gateway:     gwAddr,
-		IPAddress:   ipAddr4.IP,
-		IP4Mask:     ipAddr4.Mask,
-		Gateway6:    gwAddr6,
-		IPAddress6:  ipAddr6,		
-		Policies:    GetEndpointPoliciesFromHostComputePolicies(hcnEndpoint.Policies),
+		MacAddress: macAddr,
+		Gateway:    gwAddr,
+		IPAddress:  ipAddr4.IP,
+		IP4Mask:    ipAddr4.Mask,
+		Gateway6:   gwAddr6,
+		IPAddress6: ipAddr6,
+		Policies:   GetEndpointPoliciesFromHostComputePolicies(hcnEndpoint.Policies),
 	}
 
 }

--- a/network/policy.go
+++ b/network/policy.go
@@ -34,19 +34,14 @@ func GetPortEnumValue(protocol string) (uint32, error) {
 		switch strings.ToLower(protocol) {
 		case "tcp":
 			protocolInt = 6
-			break
 		case "udp":
 			protocolInt = 17
-			break
 		case "icmpv4":
 			protocolInt = 1
-			break
 		case "icmpv6":
 			protocolInt = 58
-			break
 		case "igmp":
 			protocolInt = 2
-			break
 		default:
 			return 0, errors.New("invalid protocol supplied to port mapping policy")
 		}

--- a/plugins/nat/nat_windows.go
+++ b/plugins/nat/nat_windows.go
@@ -1,17 +1,9 @@
 package main
 
 import (
-	//	"github.com/Microsoft/windows-container-networking/cni"
 	"github.com/Microsoft/windows-container-networking/common/core"
 )
 
-/*
-// NetPlugin represents the CNI network plugin.
-type netPlugin struct {
-	*cni.Plugin
-	nm network.Manager
-}
-*/
 func main() {
 	core.Core()
 }

--- a/plugins/sdnbridge/sdnbridge_windows.go
+++ b/plugins/sdnbridge/sdnbridge_windows.go
@@ -1,17 +1,9 @@
 package main
 
 import (
-	//	"github.com/Microsoft/windows-container-networking/cni"
 	"github.com/Microsoft/windows-container-networking/common/core"
 )
 
-/*
-// NetPlugin represents the CNI network plugin.
-type netPlugin struct {
-	*cni.Plugin
-	nm network.Manager
-}
-*/
 func main() {
 	core.Core()
 }

--- a/plugins/sdnoverlay/sdnoverlay_windows.go
+++ b/plugins/sdnoverlay/sdnoverlay_windows.go
@@ -1,17 +1,9 @@
 package main
 
 import (
-	//	"github.com/Microsoft/windows-container-networking/cni"
 	"github.com/Microsoft/windows-container-networking/common/core"
 )
 
-/*
-// NetPlugin represents the CNI network plugin.
-type netPlugin struct {
-	*cni.Plugin
-	nm network.Manager
-}
-*/
 func main() {
 	core.Core()
 }

--- a/test/utilities/container_testing.go
+++ b/test/utilities/container_testing.go
@@ -85,7 +85,7 @@ func (ci *ContainerInfo) RunContainerConnectivityTest(
 	} else {
 
 		var ipv4addr string
-		var ipv6addr string 
+		var ipv6addr string
 
 		ipv4addr, ipv6addr, err = Getv4Andv6AddressFromIPConfigList(ci.Endpoint.IpConfigurations)
 

--- a/test/utilities/testing_windows.go
+++ b/test/utilities/testing_windows.go
@@ -2,14 +2,14 @@ package util
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"github.com/Microsoft/hcsshim/hcn"
 	"github.com/Microsoft/windows-container-networking/cni"
 	"github.com/Microsoft/windows-container-networking/common"
 	"github.com/Microsoft/windows-container-networking/common/core"
 	cniSkel "github.com/containernetworking/cni/pkg/skel"
 	"net"
-	"github.com/Microsoft/hcsshim/hcn"
-	"errors"
 )
 
 const Interface = "Ethernet"
@@ -18,7 +18,7 @@ func GetDefaultInterface(getipv6 bool) (*net.Interface, *net.IP, *net.IP, error)
 	var foundv4 bool
 	var foundv6 bool
 
-	foundIp := &net.IP{}
+	var foundIp *net.IP
 	foundIpv6 := &net.IP{}
 
 	foundInterface := net.Interface{}
@@ -39,11 +39,11 @@ func GetDefaultInterface(getipv6 bool) (*net.Interface, *net.IP, *net.IP, error)
 						foundv4 = true
 					}
 
-				} else { 
+				} else {
 					if getipv6 &&
-					   !foundv6 &&
-					   !ipTemp.IsLinkLocalUnicast() &&
-					   !ipTemp.IsLoopback() {
+						!foundv6 &&
+						!ipTemp.IsLinkLocalUnicast() &&
+						!ipTemp.IsLoopback() {
 
 						foundIpv6 = &ipTemp
 						foundv6 = true
@@ -52,7 +52,7 @@ func GetDefaultInterface(getipv6 bool) (*net.Interface, *net.IP, *net.IP, error)
 
 				if foundv4 && foundv6 {
 					break
-				}	
+				}
 			}
 		}
 	}
@@ -73,7 +73,7 @@ func Getv4Andv6AddressFromIPConfigList(addrs []hcn.IpConfig) (string, string, er
 		ip := net.ParseIP(ipconf.IpAddress)
 
 		if ip == nil {
-			err = errors.New("Invalid ip address found in ipconfigurations")	
+			err = errors.New("Invalid ip address found in ipconfigurations")
 			break
 		}
 
@@ -94,10 +94,10 @@ func Getv4Andv6AddressFromIPConfigList(addrs []hcn.IpConfig) (string, string, er
 	}
 
 	if ipv4addr == nil && ipv6addr == nil {
-		err = errors.New("No ipv4 or ipv6 address present in ipconfigurations")	
-	} else if ipv4addr == nil{
+		err = errors.New("No ipv4 or ipv6 address present in ipconfigurations")
+	} else if ipv4addr == nil {
 		err = errors.New("No ip4 address present in ipconfigurations")
-	} else if ipv6addr == nil{
+	} else if ipv6addr == nil {
 		err = errors.New("No ip6 address present in ipconfigurations")
 	} else {
 		ipv4address = ipv4addr.String()
@@ -141,7 +141,9 @@ func AddCase(args cniSkel.CmdArgs) error {
 		return err
 	}
 
-	netPlugin.Add(&args)
+	if err := netPlugin.Add(&args); err != nil {
+		return fmt.Errorf("Failed to add args %v to net plugin %v: %s", args, netPlugin, err)
+	}
 	netPlugin.Stop()
 
 	return nil
@@ -161,7 +163,9 @@ func DelCase(args cniSkel.CmdArgs) error {
 		return err
 	}
 
-	netPlugin.Delete(&args)
+	if err := netPlugin.Delete(&args); err != nil {
+		return fmt.Errorf("Failed to delete test case with args %v: %s", args, err)
+	}
 	netPlugin.Stop()
 
 	return nil


### PR DESCRIPTION
While the vast majority of the changes are trivial, I'd like to draw the reviewers' attention to the following places where semantics may have slightly changed and I request you take a closer look at:
* [this switch to `strings.EqualFold()`](https://github.com/microsoft/windows-container-networking/pull/87/files#diff-377d37bad6cdf948c23b57b82a604e0e4e83fae41e40428d4c3438b971fee350R142) which has the potential to do something weird on non EN-US systems, but considering it's only used during testing and only seems to be called during tests so it should be a real-world issue.
* I have [removed the Setup/Teardown steps](https://github.com/microsoft/windows-container-networking/pull/87/files#diff-377d37bad6cdf948c23b57b82a604e0e4e83fae41e40428d4c3438b971fee350L310) from `plugin_testing.RunAll()` since both the sub-calls to `plugin_testing.{RunUnitTest,RunBasicConnectivityTest}` in turn already call `Setup()/Teardown()`. 