### PR TITLE
fix: separate config name from config type to allow creation of multiple networks

### DIFF
--- a/cni/cni.go
+++ b/cni/cni.go
@@ -246,7 +246,7 @@ func (config *NetworkConfig) GetNetworkInfo(podNamespace string) (ninfo *network
 	ninfo = &network.NetworkInfo{
 		ID:            config.Name,
 		Name:          config.Name,
-		Type:          network.NetworkType(config.Name),
+		Type:          network.NetworkType(config.Type),
 		Subnets:       subnets,
 		InterfaceName: "",
 		DNS:           dnsSettings,


### PR DESCRIPTION
Currently, we can only create one network of each type and the network must be named exactly the same as the type, e.g. I have to name my network `nat` if I want to create a NAT network. This limits our ability create any other container networks of the same type on one host.

As of [CNI Spec  0.2.0](https://github.com/containernetworking/cni/blob/spec-v0.2.0/SPEC.md#network-configuration) `type` was part of the config spec thus it is safe to assume all configs pass a type parameter but we can also add code to default to Name if Type doesn't exist to cover [this comment](https://github.com/microsoft/windows-container-networking/blob/3a5374cb7ce31b1d2136c994fba5a1ef2fa079d2/cni/cni.go#L69C1-L69C128)
 