### PR TITLE
Enable Unit Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,11 @@ jobs:
           go install ./...
         working-directory: src/github.com/Microsoft/windows-container-networking
 
+      - name: Enable ICMP V4 
+        shell: pwsh
+        run: |
+          netsh advFirewall Firewall add rule name="Enable ICMP Protocal" protocol=icmpv4:8,any dir=in action=allow
+  
       - name: Test
         run: |
           mingw32-make.exe test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,10 @@ jobs:
         shell: pwsh
         run: |
           netsh advFirewall Firewall add rule name="Enable ICMP Protocal" protocol=icmpv4:8,any dir=in action=allow
-  
+
       - name: Test
+        env: 
+          ImageToUse: ${{ matrix.os == 'windows-2022' && 'mcr.microsoft.com/windows/nanoserver:ltsc2022' || ''  }}
         run: |
           mingw32-make.exe test
         working-directory: src/github.com/Microsoft/windows-container-networking

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CNIFILES = \
 GOCMD=go
 GOLOCALENV=GO111MODULE=on GOARCH=amd64 GOOS=windows
 GOBUILD=$(GOLOCALENV) $(GOCMD) build -v -mod=vendor
-GOTEST=$(GOLOCALENV) $(GOCMD) test -v -mod=vendor
+GOTEST=$(GOLOCALENV) $(GOCMD) test -v -p 1 -mod=vendor
 
 CNI_NET_DIR = plugins
 OUTPUTDIR = out

--- a/cni/cni.go
+++ b/cni/cni.go
@@ -246,7 +246,7 @@ func (config *NetworkConfig) GetNetworkInfo(podNamespace string) (ninfo *network
 	ninfo = &network.NetworkInfo{
 		ID:            config.Name,
 		Name:          config.Name,
-		Type:          network.NetworkType(config.Name),
+		Type:          network.NetworkType(config.Type),
 		Subnets:       subnets,
 		InterfaceName: "",
 		DNS:           dnsSettings,

--- a/plugins/nat/nat_windows_test.go
+++ b/plugins/nat/nat_windows_test.go
@@ -17,7 +17,7 @@ func CreateNatTestNetwork() *hcn.HostComputeNetwork {
 }
 
 func TestNatCmdAdd(t *testing.T) {
-	t.Skip("Nat test is disabled for now.")
+	// t.Skip("Nat test is disabled for now.")
 	testDualStack = (os.Getenv("TestDualStack") == "1")
 	imageToUse = os.Getenv("ImageToUse")
 	testNetwork := CreateNatTestNetwork()

--- a/plugins/sdnbridge/sdnbridge_windows_test.go
+++ b/plugins/sdnbridge/sdnbridge_windows_test.go
@@ -21,7 +21,7 @@ func CreateBridgeTestNetwork() *hcn.HostComputeNetwork {
 }
 
 func TestBridgeCmdAdd(t *testing.T) {
-	t.Skip("Bridge test is disabled for now.")
+	// t.Skip("Bridge test is disabled for now.")
 	testDualStack = (os.Getenv("TestDualStack") == "1")
 	imageToUse = os.Getenv("ImageToUse")
 	testNetwork := CreateBridgeTestNetwork()

--- a/plugins/sdnbridge/sdnbridge_windows_test.go
+++ b/plugins/sdnbridge/sdnbridge_windows_test.go
@@ -25,7 +25,7 @@ func TestBridgeCmdAdd(t *testing.T) {
 	testDualStack = (os.Getenv("TestDualStack") == "1")
 	imageToUse = os.Getenv("ImageToUse")
 	testNetwork := CreateBridgeTestNetwork()
-	pt := util.MakeTestStruct(t, testNetwork, "sdnbridge", true, true, "", testDualStack, imageToUse)
+	pt := util.MakeTestStruct(t, testNetwork, "L2Bridge", true, true, "", testDualStack, imageToUse)
 	pt.Ipv6Url = os.Getenv("Ipv6UrlToUse")
 	pt.RunAll(t)
 }

--- a/plugins/sdnoverlay/sdnoverlay_windows_test.go
+++ b/plugins/sdnoverlay/sdnoverlay_windows_test.go
@@ -35,10 +35,10 @@ func CreateOverlayTestNetwork() *hcn.HostComputeNetwork {
 }
 
 func TestOverlayCmdAdd(t *testing.T) {
-	t.Skip("Overlay test is disabled for now.")
+	// t.Skip("Overlay test is disabled for now.")
 	testDualStack = (os.Getenv("TestDualStack") == "1")
 	imageToUse = os.Getenv("ImageToUse")
 	testNetwork := CreateOverlayTestNetwork()
-	pt := util.MakeTestStruct(t, testNetwork, "sdnoverlay", true, false, "", testDualStack, imageToUse)
+	pt := util.MakeTestStruct(t, testNetwork, "Overlay", true, false, "", testDualStack, imageToUse)
 	pt.RunAll(t)
 }

--- a/test/container/container_windows.go
+++ b/test/container/container_windows.go
@@ -5,14 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/Microsoft/go-winio/vhd"
-	"github.com/Microsoft/hcsshim"
-	runhcs "github.com/Microsoft/hcsshim/pkg/go-runhcs"
-	"github.com/Microsoft/hcsshim/test/functional/utilities"
-	runc "github.com/containerd/go-runc"
-	"github.com/opencontainers/runtime-tools/generate"
-	"github.com/pkg/errors"
-	"golang.org/x/sync/errgroup"
 	"io"
 	"io/ioutil"
 	"os"
@@ -21,6 +13,15 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/Microsoft/go-winio/vhd"
+	"github.com/Microsoft/hcsshim"
+	runhcs "github.com/Microsoft/hcsshim/pkg/go-runhcs"
+	testutilities "github.com/Microsoft/hcsshim/test/functional/utilities"
+	runc "github.com/containerd/go-runc"
+	"github.com/opencontainers/runtime-tools/generate"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -32,7 +33,6 @@ const (
 
 func PingTest(c hcsshim.Container, ip string, ipv6 bool) error {
 	var pingCommand string
-
 	if !ipv6 {
 		pingCommand = fmt.Sprintf("ping -w 8000 -n 4 %s", ip)
 	} else {

--- a/test/utilities/connectivity_testing.go
+++ b/test/utilities/connectivity_testing.go
@@ -25,7 +25,7 @@ const (
 func getDefaultDns() *cniTypes.DNS {
 	defaultDns := cniTypes.DNS{
 		//		Nameservers: []string{"8.8.8.8", "11.0.0.10"},
-		Nameservers: []string{"10.50.10.50"},
+		Nameservers: []string{"10.50.10.50", "8.8.8.8"},
 		Search:      []string{"svc.cluster.local", "svc.cluster.local"},
 	}
 	return &defaultDns

--- a/test/utilities/container_testing.go
+++ b/test/utilities/container_testing.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/Microsoft/hcsshim"
 	"github.com/Microsoft/hcsshim/hcn"
-	"github.com/Microsoft/windows-container-networking/test/container"
+	contTest "github.com/Microsoft/windows-container-networking/test/container"
 )
 
 const (

--- a/test/utilities/plugin_testing.go
+++ b/test/utilities/plugin_testing.go
@@ -170,10 +170,9 @@ func (pt *PluginUnitTest) verifyAddEndpointProperties(t *testing.T, ci *Containe
 	if !caseBlindStringComp(&ci.Endpoint.HostComputeNamespace, &ci.Namespace.Id) {
 		t.Errorf("Endpoint namespace does not match Namespace ID.")
 	}
-	// Network Id is empty at the point pt,Network is created, this validation is repeated since we query the network by name to validate it was created
-	// if !caseBlindStringComp(&ci.Endpoint.HostComputeNetwork, &pt.Network.Id) {
-	// 	t.Errorf("Endpoint network does not match Network ID.")
-	// }
+	if !caseBlindStringComp(&ci.Endpoint.HostComputeNetwork, &pt.Network.Id) {
+		t.Errorf("Endpoint network does not match Network ID.")
+	}
 	if !comparePolicyLists(ci.Endpoint.Policies, pt.Policies) {
 		t.Errorf("Endpoint policies do not match Expected Policies.")
 	}
@@ -339,6 +338,14 @@ func (pt *PluginUnitTest) RunBasicConnectivityTest(t *testing.T, numContainers i
 }
 
 func (pt *PluginUnitTest) RunAll(t *testing.T) {
+	if err := pt.Setup(t); err != nil {
+		t.Errorf("Failed to set up test case for %v: %s", pt.CniCmdArgs, err)
+	}
+	defer func() {
+		if err := pt.Teardown(t); err != nil {
+			t.Logf("WARN: failed to tear down test case for %v: %s", pt.CniCmdArgs, err)
+		}
+	}()
 	pt.RunUnitTest(t)
 	pt.RunBasicConnectivityTest(t, 2)
 }


### PR DESCRIPTION
This pr introduces the following changes to enable NAT, SDNOverlay and SDNBridge Tests Unit Tests:

- Selects Nano Server 2022 container image for Server 2022 job runner
- Changes test networking interface logic to pick the first interface available, The tests always fail if there exists a virtual ethernet interface on the test device
- Restores network plugin setup and tear down steps  to ensure correct gateway configuration and traffic routing
- Limits parallel test execution to one at a time to isolate network configuration per plugin
- Enables ICMP request to job runners


All tests are currently running fine on Server 2019. 
SDN Bridge tests are failing on the Server 2022 job runner but passing locally.