### PR TITLE
Adding an ipv6 policy for port mapping policies when dual stack is en…

### DIFF
--- a/cni/cni.go
+++ b/cni/cni.go
@@ -342,9 +342,9 @@ func (config *NetworkConfig) GetEndpointInfo(
 	runtimeConf := config.RuntimeConfig
 	logrus.Debugf("Parsing port mappings from %+v", runtimeConf.PortMappings)
 
-	flags := uint32(0)
+	flags := hcn.NatFlagsNone
 	if config.OptionalFlags.LocalRoutePortMapping {
-		flags = 1
+		flags = hcn.NatFlagsLocalRoutedVip
 	}
 	var aclPriority uint16 = 1000
 	for _, mapping := range runtimeConf.PortMappings {
@@ -354,6 +354,16 @@ func (config *NetworkConfig) GetEndpointInfo(
 		}
 		logrus.Debugf("Created raw policy from mapping: %+v --- %+v", mapping, policy)
 		epInfo.Policies = append(epInfo.Policies, policy)
+
+		if config.OptionalFlags.EnableDualStack {
+			v6flags := flags | hcn.NatFlagsIPv6
+			v6policy, err := network.GetPortMappingPolicy(mapping.HostPort, mapping.ContainerPort, mapping.Protocol, "", v6flags)
+			if err != nil {
+				return nil, fmt.Errorf("failed during GetEndpointInfo from netconf: %v", err)
+			}
+			logrus.Debugf("Created raw V6 policy from mapping: %+v --- %+v", mapping, v6policy)
+			epInfo.Policies = append(epInfo.Policies, v6policy)
+		}
 
 		if config.OptionalFlags.AllowAclPortMapping {
 			pol, err := getInACLRule(&mapping, aclPriority)

--- a/example/l2bridge-dualstack-cni-template.conf
+++ b/example/l2bridge-dualstack-cni-template.conf
@@ -1,0 +1,168 @@
+{
+    "cniVersion": "0.2.0",
+    "name": "{{NAME}}",
+    "type": "{{TYPE}}",
+    "master": "Ethernet",
+    "capabilities": {
+        "portMappings": true,
+        "dns" : true
+    },
+    "ipam": {
+        "environment": "azure",
+        "subnet": "192.168.0.0/24",
+        "routes": [
+            {
+                "GW": "192.168.0.2"
+            }
+        ]
+    },
+    "dns": {
+        "Nameservers": [
+            "{{DNSSERVER}}"
+        ],
+        "Search": [
+            "svc.cluster.local"
+        ]
+    },
+    "optionalFlags" : {
+        "localRoutedPortMapping" : true,
+        "allowAclPortMapping" : true,
+        "enableDualStack" : true,
+        "gatewayFromAdditionalRoutes" : true
+    },
+    "additionalRoutes": [
+        {
+            "GW": "10::2",
+            "Dst": "::/0"
+        }
+    ],
+    "AdditionalArgs": [
+        {
+            "Name": "EndpointPolicy",
+            "Value": {
+                "Type": "OutBoundNAT",
+                "Settings": {
+                    "Exceptions": [
+                        "192.168.0.0/24",
+                        "{{LOCAL_ENDPOINT}}/32"
+                    ]
+                }
+            }
+        }
+
+        ,{
+            "Name": "EndpointPolicy",
+            "Value": {
+                "Type": "OutBoundNAT",
+                "Settings": {
+                    "Exceptions": [
+                        "10::0/120",
+                        "{{LOCAL_ENDPOINT_IPV6}}/128"
+                    ]
+                }
+            }
+        }
+
+        ,{
+            "Name": "EndpointPolicy",
+            "Value": {
+                "Type":"ACL",
+                "Settings": {
+                    "Action": "Allow",
+                    "Protocols": "6",
+                    "LocalPorts": "1111",
+                    "Direction": "In",
+                    "Priority": 101
+                }
+            }
+        }
+        ,{
+            "Name": "EndpointPolicy",
+            "Value": {
+                "Type":"ACL",
+                "Settings": {
+                    "RemoteAddresses" : "{{LOCAL_ENDPOINT}}",
+                    "RemotePorts" : "31002",
+                    "Action": "Allow",
+                    "Protocols": "6",
+                    "Direction": "Out",
+                    "Priority": 200
+                }
+            }
+        }
+        ,{
+            "Name": "EndpointPolicy",
+            "Value": {
+                "Type":"ACL",
+                "Settings": {
+                    "RemoteAddresses" : "{{LOCAL_ENDPOINT_IPV6}}",
+                    "RemotePorts" : "31002",
+                    "Action": "Allow",
+                    "Protocols": "6",
+                    "Direction": "Out",
+                    "Priority": 200
+                }
+            }
+        }
+        ,{
+            "Name": "EndpointPolicy",
+            "Value": {
+                "Type":"ACL",
+                "Settings": {
+                    "RemoteAddresses" : "{{INFRA_PREFIX}}", 
+                    "Action": "Block",
+                    "Direction": "Out",
+                    "Priority": 1998
+                }
+            }
+        }
+        ,{
+            "Name": "EndpointPolicy",
+            "Value": {
+                "Type":"ACL",
+                "Settings": {
+                    "RemoteAddresses" : "{{INFRA_PREFIX_IPV6}}", 
+                    "Action": "Block",
+                    "Direction": "Out",
+                    "Priority": 1998
+                }
+            }
+        }
+        ,{
+            "Name": "EndpointPolicy",
+            "Value": {
+                "Type":"ACL",
+                "Settings": {
+                    "RemoteAddresses" : "192.168.0.0/24", 
+                    "Action": "Block",
+                    "Direction": "Out",
+                    "Priority": 1999
+                }
+            }
+        }
+        ,{
+            "Name": "EndpointPolicy",
+            "Value": {
+                "Type":"ACL",
+                "Settings": {
+                    "RemoteAddresses" : "10::0/120", 
+                    "Action": "Block",
+                    "Direction": "Out",
+                    "Priority": 1999
+                }
+            }
+        }
+        ,{
+            "Name": "EndpointPolicy",
+            "Value": {
+                "Type":"ACL",
+                "Settings": {
+                    "Action": "Allow",
+                    "Direction": "Out",
+                    "Priority": 2000
+                }
+            }
+        }
+
+    ]
+}

--- a/network/policy.go
+++ b/network/policy.go
@@ -53,7 +53,7 @@ func GetPortEnumValue(protocol string) (uint32, error) {
 }
 
 // GetPortMappingPolicy creates an HCN PortMappingPolicy and stores it in CNI Policy.
-func GetPortMappingPolicy(externalPort int, internalPort int, protocol string, hostIp string, flags uint32) (Policy, error) {
+func GetPortMappingPolicy(externalPort int, internalPort int, protocol string, hostIp string, flags hcn.NatFlags) (Policy, error) {
 	// protocol can be passed either as a number or a name
 	protocolInt, err := GetPortEnumValue(protocol)
 	if err != nil {
@@ -65,7 +65,7 @@ func GetPortMappingPolicy(externalPort int, internalPort int, protocol string, h
 		InternalPort: uint16(internalPort),
 		Protocol:     protocolInt,
 		VIP:          hostIp,
-		Flags:        hcn.NatFlags(flags),
+		Flags:        flags,
 	}
 	rawPolicy, _ := json.Marshal(portMappingPolicy)
 	endpointPolicy := hcn.EndpointPolicy{


### PR DESCRIPTION
…abled

Currently only ipv4 port mapping policies are added to the host for dual stack scenarios. Adding an extra policy without the VIP specified to handle ipv6 traffic. HNS will use the network's management ipv6 as the vip for nat-ing

Validation:
1. Local validation with crictl and port mapping set in the pod config file
2. Validation in a SF cluster
