### PR TITLE
feat: add missing cni 0.3.1 support

### DIFF
--- a/cni/cni.go
+++ b/cni/cni.go
@@ -28,7 +28,7 @@ const (
 )
 
 // Supported CNI versions.
-var VersionsSupported = []string{"0.2.0", "0.3.0", "0.4.0", "1.0.0"}
+var VersionsSupported = []string{"0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0"}
 
 type KVP struct {
 	Name  string          `json:"name"`


### PR DESCRIPTION
Is there any specific reason as to why the 0.3.1v spec wasn't included?
I tried updating our flannel deployment for our windows k8s nodes and it kept complaining that the version "0.3.1" we used in our cni config wasn't supported.
After adding the missing version everything  seems to work fine now