### PR TITLE
Ensure CNI only adds default routes with a valid (non-empty) gateway

### DIFF
--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -67,12 +67,11 @@ func (endpoint *EndpointInfo) GetHostComputeEndpoint() *hcn.HostComputeEndpoint 
 	gwAddr := ""
 	if endpoint.Gateway != nil {
 		gwAddr = endpoint.Gateway.String()
+		routes = append(routes, hcn.Route{
+			NextHop:           gwAddr,
+			DestinationPrefix: "0.0.0.0/0",
+		})
 	}
-
-	routes = append(routes, hcn.Route{
-		NextHop:           gwAddr,
-		DestinationPrefix: "0.0.0.0/0",
-	})
 
 	if endpoint.Gateway6 != nil {
 		gwAddr6 := endpoint.Gateway6.String()


### PR DESCRIPTION
With the new endpoint routes support in HNS, we are now storing routes as part of endpoint. 

For IPv6, the default routes look good. For IPv4, NAT CNI does not store a gateway address in the endpoint and adds a faulty default route to the endpoint with an empty gateway address, indicated by NextHop="". This is not a valid route:
```go
hcn.Route{
            NextHop:           "",
            DestinationPrefix: "0.0.0.0/0",
        } 
```
Passing this invalid route would lead to errors when creating pods, due to the new behavior in HNS. This PR should ensure that only a default route gets added when a gateway address is present. Otherwise, if there is no GW address provided, no faulty routes will be added to the endpoint, which is already supported by existing HNS behavior.