### PR TITLE
Update go version to 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
       - master
 
 env:
-  GO_VERSION: 1.21.1
+  GO_VERSION: 1.23
 
 permissions:
   contents: read
@@ -39,9 +39,9 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.52.2
+          version: v1.62.2
           skip-cache: true
           args: --timeout=8m
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 name: Release
 
 env:
-  GO_VERSION: 1.21.1
+  GO_VERSION: 1.23
   BINARY_ARTIFACT_NAME: "windows-cni-binaries"
   RELEASE_NOTES_ARTIFACT_NAME: "windows-cni-release-notes"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated Go version to 1.23
+- Updated golangci-lint to v1.62.2 for Go 1.23 compatibility
+- Updated vendored dependencies for Go 1.23
+
 ## [v0.3.2] - 2025-11-21
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ OUTPUTDIR = out
 # Containerized build parameters.
 # Based on Azure/aks-engine Makefile
 REPO_PATH := github.com/Microsoft/windows-container-networking
-DEV_ENV_IMAGE := golang:1.21
+DEV_ENV_IMAGE := golang:1.23
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_OPTS := --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_VARS}
 # Multi-stage Dockerfile that creates the final image from golang:1.21.1

--- a/cni/cni.go
+++ b/cni/cni.go
@@ -239,7 +239,7 @@ func (config *NetworkConfig) GetNetworkInfo(podNamespace string) (ninfo *network
 		ip, s, _ := net.ParseCIDR(config.Ipam.Subnet)
 		gatewayIP := ip.To4()
 		gatewayIP[3]++
-		if config.Ipam.Routes != nil && len(config.Ipam.Routes) > 0 && config.Ipam.Routes[0].GW != nil {
+		if len(config.Ipam.Routes) > 0 && config.Ipam.Routes[0].GW != nil {
 			gatewayIP = config.Ipam.Routes[0].GW
 		}
 		subnet := network.SubnetInfo{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Microsoft/windows-container-networking
 
-go 1.21.1
+go 1.23
 
 require (
 	github.com/Microsoft/go-winio v0.5.2

--- a/test/container/container_windows.go
+++ b/test/container/container_windows.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -323,7 +322,7 @@ func (t *testIO) Wait() error {
 }
 
 func readPidFile(path string) (int, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return -1, errors.Wrap(err, "failed to read pidfile")
 	}
@@ -335,7 +334,7 @@ func readPidFile(path string) (int, error) {
 }
 
 func createTempDir(t *testing.T) string {
-	tempDir, err := ioutil.TempDir("", "test")
+	tempDir, err := os.MkdirTemp("", "test")
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %s", err)
 	}
@@ -367,7 +366,7 @@ func getLayers(t *testing.T, imageName string) []string {
 
 func getLayerChain(t *testing.T, layerFolder string) []string {
 	jPath := filepath.Join(layerFolder, "layerchain.json")
-	content, err := ioutil.ReadFile(jPath)
+	content, err := os.ReadFile(jPath)
 	if os.IsNotExist(err) {
 		t.Fatalf("layerchain not found")
 	} else if err != nil {


### PR DESCRIPTION
- Updated Go version to 1.23
- Updated golangci-lint to v1.62.2 for Go 1.23 compatibility
- Updated vendored dependencies for Go 1.23